### PR TITLE
fix: migrate from Git Flow to trunk-based development

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on:
   push:
     branches:
-      - master
-      - develop
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,8 +3,7 @@ name: code-quality
 on:
   push:
     branches:
-      - master
-      - develop
+      - main
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module.exports = require('@studiometa/prettier-config');
 
 ## Contributing
 
-This project uses [Git Flow](https://github.com/petervanderdoes/gitflow-avh) as a branching model, new feature will be added by pull-requests of `feature/` branches against `develop`. 
+This project uses a trunk-based development model, new features are added by pull-requests against `main`.
 
 The JS files are linted with [ESLint](https://eslint.org/) and [Prettier](https://prettier.io). You can check for linting errors before your commits by running the following scripts with Yarn:
 


### PR DESCRIPTION
## Changes

- Update CI workflows to trigger on `main` instead of `master`/`develop`
- Update README contributing section to reflect trunk-based model

This is part of the migration from Git Flow (master/develop) to trunk-based development (main).